### PR TITLE
Refactor getClueIds null check in GetButton component

### DIFF
--- a/src/components/scan/GetButton.tsx
+++ b/src/components/scan/GetButton.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useUserStore } from "@/libs/store";
-import {getUser, updateUserGetClues} from "@/hooks/supabase/useUserFunctions";
+import { getUser, updateUserGetClues } from "@/hooks/supabase/useUserFunctions";
 import { User } from "@/types/tableType";
 import { useRouter } from "next/router";
 
@@ -48,9 +48,8 @@ const GetButton = (props: Props) => {
     const currentModel = ClUES[props.currentModel as ModelKeys ];
     const getClueIds = user?.get_clues?.split(",") as string[];
 
-    if (getClueIds.includes(currentModel.id.toString())) {
+    if (getClueIds && getClueIds.includes(currentModel.id.toString())) {
       console.log("get_cluesに存在する");
-      return;
     } else {
       console.log("get_cluesに存在しない");
       // 存在しない場合


### PR DESCRIPTION
Moved the null check for getClueIds inside the condition that checks if the id exists in get_clues. This will prevent errors for users that do not have an associated get_clues string array. Previously, if a user did not have any get_clues, the system would error out due to trying to run an includes check on an undefined value.