### PR TITLE
"Refactor GetButton to fix undefined clues issue"

### DIFF
--- a/src/components/scan/GetButton.tsx
+++ b/src/components/scan/GetButton.tsx
@@ -58,7 +58,12 @@ const GetButton = (props: Props) => {
       console.log("get_cluesに存在しない");
       // 存在しない場合
 
-      const newGetClues = user?.get_clues + "," + currentModel.id;
+      let newGetClues;
+      if (!getClueIds) {
+        newGetClues = currentModel.id.toString();
+      } else {
+        newGetClues = user?.get_clues + "," + currentModel.id;
+      }
 
       // Supabaseのuserテーブルのget_cluesにprops.currentModelのidを追加
       await updateUserGetClues(user?.id as string, newGetClues);


### PR DESCRIPTION
Updated the GetButton component to prevent concatenation with undefined 'get_clues'. Previously, the code always concatenated the current model ID with the 'get_clues' variable, but if this variable did not exist, it resulted in the creation of a string starting with undefined. The current change now includes a check for the existence of 'get_clues' before concatenation, thereby preventing the creation of inconsistent IDs.