### PR TITLE
Add new webar_logo.svg to public images

### DIFF
--- a/public/images/webar_logo.svg
+++ b/public/images/webar_logo.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="_レイヤー_1" data-name="レイヤー 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 382.56 56.06">
+    <defs>
+        <style>
+            .cls-1 {
+            letter-spacing: .02em;
+            }
+
+            .cls-2 {
+            letter-spacing: .25em;
+            }
+
+            .cls-3 {
+            fill: #d1d5db;
+            font-family: Corporate-Logo-Bold-ver2, 'Corporate Logo ver2';
+            font-size: 48px;
+            font-weight: 700;
+            }
+
+            .cls-4 {
+            letter-spacing: 0em;
+            }
+
+            .cls-5 {
+            letter-spacing: 0em;
+            }
+        </style>
+    </defs>
+    <text class="cls-3" transform="translate(0 42.24)">
+        <tspan class="cls-4" x="0" y="0">WebA</tspan>
+        <tspan class="cls-2" x="135.98" y="0">R</tspan>
+        <tspan class="cls-4" x="181.77" y="0">推</tspan>
+        <tspan class="cls-1" x="229.58" y="0">理ゲ</tspan>
+        <tspan class="cls-5" x="317.71" y="0">ーム</tspan>
+    </text>
+</svg>


### PR DESCRIPTION
This commit adds a new SVG logo for WebAR. The SVG contains specific styling and letter-spacing for its elements. This new logo enhances the visual aesthetics on the site and promotes the brand more effectively.