### PR TITLE
Update result page button text and add alert

### DIFF
--- a/src/pages/result/index.tsx
+++ b/src/pages/result/index.tsx
@@ -36,10 +36,11 @@ const Result = () => {
               }}
               className="boxShadow mb-5 flex w-full items-center justify-center rounded bg-theme-red py-2.5 text-lg tracking-widest text-white"
               onClick={() => {
+                alert("まだ");
                 storyStart();
               }}
             >
-              <p className="px-3">最終ストーリーを見る</p>
+              <p className="px-3">事件の真相を見る</p>
             </Link>
             <Link
               href={{


### PR DESCRIPTION
Changed the text of the result page button from "See the final story" to "See the truth of the incident". Added an alert pop-up to notify users that the feature is not yet ready. This is to avoid confusion and better communicate the current development state to the user.