### PR TITLE
Increase chair model scale in scan page

### DIFF
--- a/src/pages/scan.tsx
+++ b/src/pages/scan.tsx
@@ -117,7 +117,7 @@ const Scan = () => {
             break;
 
           case "chair":
-            model.scale.set(3, 3, 3);
+            model.scale.set(10, 10, 10);
             model.position.set(0, 0, 0);
             model.rotation.set(0, Math.PI, 0);
             break;


### PR DESCRIPTION
Adjusted the scale of the chair model from 3 to 10 in the scan page to ensure a better user experience and accurately represent the chair's size. The previous scale of 3 was too small making it difficult for users to interact with the model.