### PR TITLE
Hide browser default scrollbar in global styles

### DIFF
--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -5,12 +5,25 @@
 * {
   margin: 0;
   padding: 0;
+
+  *::-webkit-scrollbar {
+    width: 0px;
+  }
+
+  &::-webkit-scrollbar-track {
+    opacity: 0;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    opacity: 0;
+  }
 }
 
 body {
   background-color: #1d1e22;
   color: white;
 }
+
 
 video {
   max-width: none;


### PR DESCRIPTION
This commit removes the default browser scrollbar from all the elements by setting their opacity to 0 in the global styles file. This change is made to provide a more seamless user experience and consistent design across different browsers.